### PR TITLE
Initial package skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 __pycache__
+.pytest_cache/
 
 # C extensions
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+
+python:
+  - 2.7
+
+env:
+  - PSA_BUNDLE=legacy  # Ficus
+  - PSA_BUNDLE=stable  # Ginkgo
+  - PSA_BUNDLE=latest
+
+cache: false  # Ensure no leftovers from different build environments
+  
+before_install:
+  - pip install --upgrade pip
+
+install:
+  - pip install -r requirements/test.txt
+  - pip install -r requirements/${PSA_BUNDLE}-psa.txt
+
+script:
+  - py.test

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+
+Copyright (c) 2018 NodeRabbit Inc., d.b.a. Appsembler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,41 @@
+Trinity OAuth 2 Backend
+=============================
+
+|travis-badge| |codecov-badge| |pyversions-badge| |license-badge|
+
+Overview (please modify)
+------------------------
+
+An OAuth backend for Texas Gateway (Trinity), mostly used for Open edX but can be used elsewhere.
+
+License
+-------
+
+The code in this repository is licensed under the MIT License unless
+otherwise noted.
+
+Please see ``LICENSE.txt`` for details.
+
+Reporting Security Issues
+-------------------------
+
+Please do not report security issues in public. Please email security@appsembler.org.
+
+Getting Help
+------------
+
+.. |travis-badge| image:: https://travis-ci.org/appsembler/trinity-oauth-backend.svg?branch=master
+    :target: https://travis-ci.org/appsembler/trinity-oauth-backend
+    :alt: Travis
+
+.. |codecov-badge| image:: http://codecov.io/github/appsembler/trinity-oauth-backend/coverage.svg?branch=master
+    :target: http://codecov.io/github/appsembler/trinity-oauth-backend?branch=master
+    :alt: Codecov
+
+.. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/trinity-oauth-backend.svg
+    :target: https://pypi.python.org/pypi/trinity-oauth-backend/
+    :alt: Supported Python versions
+
+.. |license-badge| image:: https://img.shields.io/github/license/appsembler/trinity-oauth-backend.svg
+    :target: https://github.com/appsembler/trinity-oauth-backend/blob/master/LICENSE.txt
+    :alt: License

--- a/requirements/latest-psa.txt
+++ b/requirements/latest-psa.txt
@@ -1,0 +1,3 @@
+# Latest Python Social Auth
+social-auth-app-django
+social-auth-core

--- a/requirements/legacy-psa.txt
+++ b/requirements/legacy-psa.txt
@@ -1,0 +1,2 @@
+# Legacy Python Social Auth, found in Open edX Ficus
+python-social-auth==0.2.21

--- a/requirements/stable-psa.txt
+++ b/requirements/stable-psa.txt
@@ -1,0 +1,3 @@
+# Stable Python Social Auth, found in Open edX Ginkgo
+social-auth-app-django==1.2.0
+social-auth-core==1.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,5 @@
+# Packages for testing
+pytest==3.5.0
+httpretty==0.8.14
+unittest2==1.1.0
+-e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# pylint: disable=C0111,W6005,W6100
+
+import os
+import re
+
+from setuptools import setup
+
+
+def get_version(*file_paths):
+    """
+    Extract the version string from the file at the given relative path fragments.
+    """
+    filename = os.path.join(os.path.dirname(__file__), *file_paths)
+    version_file = open(filename).read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError('Unable to find version string.')
+
+
+VERSION = get_version('trinity_oauth_backend', '__init__.py')
+
+README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+
+setup(
+    name='trinity-oauth-backend',
+    version=VERSION,
+    description='An OAuth backend for Texas Gateway (Trinity), mostly used for Open edX but can be used elsewhere.',
+    long_description=README,
+    author='Omar Al-Ithawi',
+    author_email='omar@appsembler.com',
+    url='https://github.com/appsembler/trinity-oauth-backend',
+    packages=[
+        'trinity_oauth_backend',
+    ],
+    include_package_data=True,
+    zip_safe=False,
+    keywords='Appsembler OAuth Trinity Texas-Gateway',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+    ],
+)

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+Test utilities.
+
+Since py.test discourages putting __init__.py into test directory (i.e. making tests a package)
+one cannot import from anywhere under tests folder. However, some utility classes/methods might be useful
+in multiple test modules (i.e. factoryboy factories, base test classes). So this package is the place to put them.
+"""

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,7 @@
+"""
+Tests for the `trinity-oauth-backend` models module.
+"""
+
+
+def test_the_truth():
+    assert True, 'Should be true!'

--- a/trinity_oauth_backend/__init__.py
+++ b/trinity_oauth_backend/__init__.py
@@ -1,0 +1,6 @@
+"""
+An OAuth backend for Texas Gateway (Trinity), mostly used for Open edX but can be used elsewhere.
+"""
+
+
+__version__ = '0.1.0'

--- a/trinity_oauth_backend/backend.py
+++ b/trinity_oauth_backend/backend.py
@@ -1,0 +1,3 @@
+"""
+The Texas Gateway OAuth 2 backend.
+"""


### PR DESCRIPTION
### Description
This is a cookie cutter PR that won't include any actual backend code. It's main purpose to get TravisCI and the python package related files.

### TODO

 - [x] Support multiple Python Social Auth versions (for Ficus, Ginkgo and social_core `master`)
 - [ ] ~Support all the Python versions that both social_core and python-social-auth supports~
   - :point_up: is just too much. I'll leave it only for Python 2.7
 - [ ] ~Quality checks borrowed from social_core~
   - :point_up: also too much!