### PR TITLE
Trinity backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ install:
   - pip install -r requirements/${PSA_BUNDLE}-psa.txt
 
 script:
+  - pycodestyle
+  - pyflakes .
   - py.test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,6 @@
 pytest==3.5.0
 httpretty==0.8.14
 unittest2==1.1.0
+pycodestyle==2.4.0
+pyflakes==1.6.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 def get_version(*file_paths):
     """
-    Extract the version string from the file at the given relative path fragments.
+    Extract the version string from the file at the given relative path.
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
     version_file = open(filename).read()
@@ -28,7 +28,8 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 setup(
     name='trinity-oauth-backend',
     version=VERSION,
-    description='An OAuth backend for Texas Gateway (Trinity), mostly used for Open edX but can be used elsewhere.',
+    description=('An OAuth backend for Texas Gateway (Trinity), '
+                 'mostly used for Open edX but can be used elsewhere.'),
     long_description=README,
     author='Omar Al-Ithawi',
     author_email='omar@appsembler.com',

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -1,7 +1,0 @@
-"""
-Test utilities.
-
-Since py.test discourages putting __init__.py into test directory (i.e. making tests a package)
-one cannot import from anywhere under tests folder. However, some utility classes/methods might be useful
-in multiple test modules (i.e. factoryboy factories, base test classes). So this package is the place to put them.
-"""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,86 @@
+"""
+Tests for the `trinity-oauth-backend` models module.
+"""
+
+import json
+
+try:
+    from social.tests.backends.oauth import OAuth2Test
+    from social.exceptions import AuthException
+except ImportError:
+    from social_core.tests.backends.oauth import OAuth2Test
+    from social_core.exceptions import AuthException
+
+
+class TrinityOauth2Test(OAuth2Test):
+    backend_path = 'trinity_oauth_backend.backend.TrinityOauth2'
+    user_data_url = 'https://pass.texasgateway.org/api/v1/user/me'
+    expected_username = 'malik'
+    access_token_body = json.dumps({
+        'access_token': '547cac21118ae7',
+        'token_type': 'bearer',
+        'expires_in': 2592000,
+        'refresh_token': '00a3aae641658d',
+    })
+    user_data_body = json.dumps({
+        'first_name': 'Malik',
+        'last_name': 'Anas',
+        'email': 'malik@appsembler.com',
+        'username': 'malik',
+        'original_district': 'District 9',
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_redirect_state_settings(self):
+        """
+        Tests for the redirect state option.
+
+        From Python Social Auth docs (https://tinyurl.com/psa-redirect-state)
+
+        > For those providers that don't recognise the state parameter, the
+        > app can add a redirect_state argument to the redirect_uri to mimic
+        > it. Set this value to False if the provider likes to
+        > verify the redirect_uri value and this
+        > parameter invalidates that check.
+
+        So, when enabling it, we should double check with Trinity
+        """
+        message = 'Trinity backend PROBABLY do not support this parameter'
+        assert not self.backend.REDIRECT_STATE, message
+
+    def test_backend_configs(self):
+        # Changing it is probably backward incompatible
+        assert self.backend.name == 'trinity'
+
+        assert self.backend.ACCESS_TOKEN_METHOD == 'POST'
+        assert self.backend.SCOPE_SEPARATOR == ','
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()
+
+    def test_staging_url(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_TRINITY_ENVIRONMENT': 'staging',
+        })
+
+        assert self.backend.base_url == 'https://pass-staging.texasgateway.org'
+
+    def test_production_url(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_TRINITY_ENVIRONMENT': 'production',
+        })
+
+        assert self.backend.base_url == 'https://pass.texasgateway.org'
+
+    def test_default_production_url(self):
+        assert self.backend.base_url == 'https://pass.texasgateway.org'
+
+    def test_invalid_environment(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_TRINITY_ENVIRONMENT': 'dev',
+        })
+
+        with self.assertRaises(AuthException):
+            print(self.backend.base_url)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,7 +1,0 @@
-"""
-Tests for the `trinity-oauth-backend` models module.
-"""
-
-
-def test_the_truth():
-    assert True, 'Should be true!'

--- a/trinity_oauth_backend/__init__.py
+++ b/trinity_oauth_backend/__init__.py
@@ -1,5 +1,7 @@
 """
-An OAuth backend for Texas Gateway (Trinity), mostly used for Open edX but can be used elsewhere.
+An OAuth backend for Texas Gateway (Trinity).
+
+It's mostly used for Open edX but can be used elsewhere.
 """
 
 

--- a/trinity_oauth_backend/backend.py
+++ b/trinity_oauth_backend/backend.py
@@ -1,3 +1,76 @@
 """
 The Texas Gateway OAuth 2 backend.
 """
+
+try:
+    from social.backends.oauth import BaseOAuth2
+    from social.exceptions import AuthException
+except ImportError:
+    from social_core.backends.oauth import BaseOAuth2
+    from social_core.exceptions import AuthException
+
+from urllib import urlencode
+
+
+class TrinityOauth2(BaseOAuth2):
+    name = 'trinity'
+    REDIRECT_STATE = False
+    ACCESS_TOKEN_METHOD = 'POST'
+    SCOPE_SEPARATOR = ','
+    EXTRA_DATA = [
+        ('email', 'email'),
+        ('username', 'username'),
+        ('fullname', 'fullname'),
+        ('district', 'district'),
+    ]
+
+    @property
+    def base_url(self):
+        env = self.setting('ENVIRONMENT', default='production')
+
+        if env == 'staging':
+            return 'https://pass-staging.texasgateway.org'
+        elif env == 'production':
+            return 'https://pass.texasgateway.org'
+
+        raise AuthException(
+            'Invalid Trinity environment was found `{env}`, '
+            'valid choices are `production` and `staging`.'.format(
+                env=env,
+            ))
+
+    def authorization_url(self):
+        return '{base_url}/oauth/v2/auth'.format(base_url=self.base_url)
+
+    def access_token_url(self):
+        return '{base_url}/oauth/v2/token'.format(base_url=self.base_url)
+
+    def get_user_details(self, response):
+        """Return user details from Trinity account"""
+        fullname, _first_name, _last_name = self.get_user_names(
+            fullname='',
+            first_name=response.get('first_name', ''),
+            last_name=response.get('last_name', ''),
+        )
+
+        return {
+            'username': response.get('username'),
+            'email': response.get('email') or '',
+            'fullname': fullname or '',
+            'district': response.get('original_district'),
+        }
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Loads user data from service"""
+        url = '{base_url}/api/v1/user/me?{params}'.format(
+            base_url=self.base_url,
+            params=urlencode({
+                'access_token': access_token,
+            })
+        )
+
+        return self.get_json(url)
+
+    def get_user_id(self, details, response):
+        """Use trinity username as unique id"""
+        return details['email']


### PR DESCRIPTION
Trinity OAuth backend.

To be installed as an extra requirement, by using the unmodified Python Social Auth. This backend should work on both Python Social Auth (used in Ficus) and Social Core (used in Ginkgo).

### TODO

 - [x] Add pep8 and pyflakes
 - [ ] ~Coverage, do we need it?~
   * I'll postpone this one.

### Open Questions
 - [x] What does `# DEFAULT_SCOPE = ['email']` mean and why it's commented?
 - [x] Why `REDIRECT_STATE` is set to `False`?
      - We'll keep it as-is, till we reach that [Trinity card enrollment](https://trello.com/c/Xi2XGHCy/2311-16-support-enrollment-while-doing-sso-redirects-for-trinity)
 